### PR TITLE
Fix title escaping in "Recent on EA Blogs" sidebar

### DIFF
--- a/provisioning/cookbooks/lesswrong/templates/default/development.ini.erb
+++ b/provisioning/cookbooks/lesswrong/templates/default/development.ini.erb
@@ -97,7 +97,6 @@ meetup_grace_period = 3600
 
 solr_url =
 
-google_api_key = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbbbbb_cccccccccccccccccc-d
 SECRET    = abcdefghijklmnopqrstuvwxyz0123456789
 MODSECRET = abcdefghijklmnopqrstuvwxyz0123456789
 tracking_secret = abcdefghijklmnopqrstuvwxyz0123456789

--- a/r2/example.ini
+++ b/r2/example.ini
@@ -100,7 +100,6 @@ dashboard_visits_period = 43200
 
 solr_url =
 
-google_api_key = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbbbbb_cccccccccccccccccc-d
 SECRET    = abcdefghijklmnopqrstuvwxyz0123456789
 MODSECRET = abcdefghijklmnopqrstuvwxyz0123456789
 tracking_secret = abcdefghijklmnopqrstuvwxyz0123456789

--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -1954,6 +1954,10 @@ div.tools a.subscription,
   padding: 0;
 }
 
+#side-meetups .add .label {
+  cursor: pointer;
+}
+
 div.tools a.edit,
 div.comment-links ul li.edit a
 {

--- a/r2/r2/templates/reddit.html
+++ b/r2/r2/templates/reddit.html
@@ -104,7 +104,7 @@
     <script src="${static('ie8below.js')}"  type="text/javascript"></script>
     <![endif]-->
 
-  <script type="text/javascript" src="http://www.google.com/jsapi?key=${g.google_api_key}"></script>
+  <script type="text/javascript" src="http://www.google.com/jsapi"></script>
 </%def>
 
 <%def name="javascript_run()">

--- a/r2/test.ini
+++ b/r2/test.ini
@@ -18,9 +18,9 @@ memcaches = 127.0.0.1:11215
 permacaches = 127.0.0.1:11215
 rendercaches = 127.0.0.1:11215
 rec_cache = 127.0.0.1:11311
-tracker_url = 
-adtracker_url = 
-clicktracker_url = 
+tracker_url =
+adtracker_url =
+clicktracker_url =
 
 main_db_name = reddit_test
 main_db_host = 127.0.0.1
@@ -61,7 +61,7 @@ monitored_servers = localhost
 
 #query cache settings
 num_query_queue_workers = 0
-query_queue_worker = 
+query_queue_worker =
 enable_doquery = False
 use_query_cache = False
 write_query_queue = False
@@ -76,12 +76,12 @@ max_sr_images = 20
 
 login_cookie = reddit_session
 domain = lesswrong.local
-domain_prefix = 
+domain_prefix =
 default_sr = lesswrong
 blessed_sr = overcomingbias
 front_page_title = Less Wrong
 admins = admin
-sponsors = 
+sponsors =
 page_cache_time = 1
 wiki_page_cache_time = 86400
 static_path = /static/
@@ -93,9 +93,8 @@ geoip_db_path = /usr/share/GeoIP/GeoIP.dat
 # The radius in km for a meetup to be considered nearby
 meetups_radius = 100
 
-solr_url =  
+solr_url =
 
-google_api_key = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbbbbb_cccccccccccccccccc-d
 SECRET    = abcdefghijklmnopqrstuvwxyz0123456789
 MODSECRET = abcdefghijklmnopqrstuvwxyz0123456789
 tracking_secret = abcdefghijklmnopqrstuvwxyz0123456789
@@ -103,7 +102,7 @@ tracking_secret = abcdefghijklmnopqrstuvwxyz0123456789
 # set X-forwarded-for and set this to true
 trust_local_proxies = false
 # hash for validating HTTP_TRUE_CLIENT_IP_HASH
-ip_hash = 
+ip_hash =
 S3KEY_ID = ABCDEFGHIJKLMNOP1234
 S3SECRET_KEY = aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890AbCd
 s3_thumb_bucket = /lesswrong.dev/
@@ -135,7 +134,7 @@ new_link_share_delay = 5 minutes
 share_reply = noreply@yourdomain.com
 
 #user-agents to limit
-agents = 
+agents =
 
 feedback_email = abuse@localhost
 
@@ -175,4 +174,3 @@ beaker.session_secret = somesecret
 # Debug mode will enable the interactive debugging tool, allowing ANYONE to
 # execute malicious code after an exception is raised.
 #set debug = false
-


### PR DESCRIPTION
![escaping](https://cloud.githubusercontent.com/assets/1735266/8249397/4205cb9a-161e-11e5-856a-a4cc7f9be505.png)
