### PR TITLE
Remove Good Ventures from blog list because it's a duplicate of GiveWell

### DIFF
--- a/provisioning/cookbooks/lesswrong/templates/default/development.ini.erb
+++ b/provisioning/cookbooks/lesswrong/templates/default/development.ini.erb
@@ -85,7 +85,7 @@ page_cache_time = 30
 static_path = /static/
 useragent = Mozilla/5.0 (compatible; bot/1.0; ChangeMe)
 
-feedbox_urls = http://www.overcomingbias.com/feed, http://slatestarcodex.com/feed, http://reflectivedisequilibrium.blogspot.com/feeds/posts/default, http://feeds.feedburner.com/TheGivewellBlog?format=xml, http://80000hours.org/blog/feed.atom, http://www.goodventures.org/feeds/blog, http://rationality.org/blog/feed/, http://feeds.feedburner.com/EverydayUtilitarian?format=xml, http://www.jefftk.com/news.rss, http://www.givinggladly.com/feeds/posts/default
+feedbox_urls = http://www.overcomingbias.com/feed, http://slatestarcodex.com/feed, http://reflectivedisequilibrium.blogspot.com/feeds/posts/default, http://feeds.feedburner.com/TheGivewellBlog?format=xml, http://80000hours.org/blog/feed.atom, http://rationality.org/blog/feed/, http://feeds.feedburner.com/EverydayUtilitarian?format=xml, http://www.jefftk.com/news.rss, http://www.givinggladly.com/feeds/posts/default
 recent_edits_feed = http://wiki.lesswrong.com/mediawiki/index.php?title=Special:RecentChanges&feed=atom&hideminor=1&namespace=0
 # Your sitemeter.com username/codename
 site_meter_codename =


### PR DESCRIPTION
Resolves https://github.com/tog22/eaforum/issues/25.  By @arichard4 