### PR TITLE
Meetups fix (2nd part)

### DIFF
--- a/r2/r2/templates/showmeetup.html
+++ b/r2/r2/templates/showmeetup.html
@@ -1,4 +1,3 @@
-<%namespace file="utils.html" import="userlink_profile"/>
 <%!
   from routes.util import url_for
   from r2.lib.filters import safemarkdown,unsafe


### PR DESCRIPTION
The previous PR to Trike on this issue (PR #18 ) from tog22's fork missed one line of the change, and therefore didn't actually fix the meetup issue. The import of userlink_profile needs to removed for the meetup to be created correctly. (Issue: tog22#29 )