### PR TITLE
Always display the header user info to logged-in users.

### DIFF
--- a/r2/r2/public/static/main.js
+++ b/r2/r2/public/static/main.js
@@ -5,9 +5,7 @@ $(document).ready(function() {
 
   var userInfo = $('<div id="user-info">');
   var pathname = window.location.pathname;
-  // This if statement prevents the viewed user being displayed as the logged in
-  // user when viewing a user's profile without being logged on
-  if ($("#side-status h2").length > 1 || !/^\/user\/([^\/]*)\/(.*)/.exec(pathname)) {
+  if (logged) {
     // username - using last child so when viewing another user their details
     // stay in right box
     $("#side-status h2").last().appendTo(userInfo);


### PR DESCRIPTION
Am I correct that we always want to show the logged-in header to logged-in users? I may be overlooking a reason for the more-complicated previous implementation.