### PR TITLE
Show that user is signed in after logging in after voting.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -28,7 +28,9 @@ from pylons.controllers.util import etag_cache
 
 import hashlib
 import httplib
+import urllib
 import urllib2
+import urlparse
 from validator import *
 
 from r2.models import *
@@ -401,7 +403,25 @@ class ApiController(RedditController):
           user.create_draft_sr()
 
         dest = dest or request.referer or '/'
-        res._redirect(dest)
+
+        # The code below adds query parameter to force the header to
+        # refresh and show that the user is logged in.
+        # TODO: This is a hack, and it doesn't work if the user clicks
+        # on an anchor element after logging in because the query
+        # param will disappear.
+        # TODO: This function should be in a different file.
+        # From http://stackoverflow.com/a/12897375:
+        def set_query_parameter(url, param_name, param_value):
+            scheme, netloc, path, query_string, fragment = urlparse.urlsplit(url)
+            query_params = urlparse.parse_qs(query_string)
+
+            query_params[param_name] = [param_value]
+            new_query_string = urllib.urlencode(query_params, doseq=True)
+
+            return urlparse.urlunsplit((scheme, netloc, path, new_query_string, fragment))
+
+        dest_with_param = set_query_parameter(dest, "refresh", "true")
+        res._redirect(dest_with_param)
 
     @Json
     @validate(user = VLogin(['user_login', 'passwd_login']),


### PR DESCRIPTION
Not excellent, but better than the current behavior. There may be a one-line change that would accomplish the same thing.

Fixes tog22/eaforum#8.

