### PR TITLE
RSS feed: Fix pluralization of "votes."

### DIFF
--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -6,16 +6,16 @@
 ## software over a computer network and provide for limited attribution for the
 ## Original Developer. In addition, Exhibit A has been modified to be consistent
 ## with Exhibit B.
-## 
+##
 ## Software distributed under the License is distributed on an "AS IS" basis,
 ## WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 ## the specific language governing rights and limitations under the License.
-## 
+##
 ## The Original Code is Reddit.
-## 
+##
 ## The Original Developer is the Initial Developer.  The Initial Developer of
 ## the Original Code is CondeNet, Inc.
-## 
+##
 ## All portions of the code written by CondeNet are Copyright (c) 2006-2008
 ## CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -27,7 +27,7 @@
    from r2.lib.filters import cleanhtml
    from r2.lib.utils import rfc822format
 %>
-<% 
+<%
    com_label = ungettext("comment", "comments", thing.num_comments)
    url = add_sr(thing.permalink, force_hostname = True)
    use_thumbs = thing.thumbnail and not request.GET.has_key("nothumbs")
@@ -40,7 +40,7 @@
   <description>
     <%
       domain = get_domain(cname = c.cname, subreddit = False)
-      votes = thing.score_fmt(thing.score)['label']
+      votes = int(thing.score_fmt(thing.score)['label'])
       votes_lbl = ungettext("vote", "votes", votes)
     %>
     Submitted by &lt;a href="http://${domain}/user/${thing.author.name}"&gt;${thing.author.name}&lt;/a&gt;
@@ -58,4 +58,3 @@
     <media:thumbnail url="${thing.thumbnail}" />
   %endif
 </item>
-


### PR DESCRIPTION
The variable `votes_lbl` was always "votes" because `votes` was a string instead of an int. So it would display "1 votes."