### PR TITLE
RSS feed: Place "Effective Altruism Forum" first in title.

### DIFF
--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -187,7 +187,7 @@ class ListingController(RedditController):
 
     def title(self):
         """Page <title>"""
-        return "%s - %s" % (self.title_text, c.site.title)
+        return "%s - %s" % (c.site.title, self.title_text)
 
     def rightbox(self):
         """Contents of the right box when rendering"""


### PR DESCRIPTION
In Feedly, the bit after the hyphen was chopped off, so the title was just "Newest Submissions," which seems less easily identifiable.

![newest-submissions](https://cloud.githubusercontent.com/assets/1735266/14770521/abaeeaf0-0a28-11e6-91fb-51e1ae800bfd.png)
