### PR TITLE
Remove tag input box

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -300,8 +300,8 @@ class ApiController(RedditController):
               continue_editing = VBoolean('keep_editing'),
               notify_on_comment = VBoolean('notify_on_comment'),
               cc_licensed = VBoolean('cc_licensed'),
-              tags = VTags('tags'))
-    def POST_submit(self, res, l, new_content, title, save, continue_editing, sr, ip, tags, notify_on_comment, cc_licensed):
+    )
+    def POST_submit(self, res, l, new_content, title, save, continue_editing, sr, ip, notify_on_comment, cc_licensed):
         res._update('status', innerHTML = '')
         should_ratelimit = sr.should_ratelimit(c.user, 'link') if sr else True
 
@@ -339,7 +339,7 @@ class ApiController(RedditController):
         # TODO: include article body in arguments to Link model
         # print "\n".join(request.post.va)
         if not l:
-          l = Link._submit(request.post.title, new_content, c.user, sr, ip, tags, spam,
+          l = Link._submit(request.post.title, new_content, c.user, sr, ip, spam,
                            notify_on_comment=notify_on_comment, cc_licensed=cc_licensed)
           if save == 'on':
               r = l._save(c.user)
@@ -364,7 +364,6 @@ class ApiController(RedditController):
           l.cc_licensed = cc_licensed
           l.change_subreddit(sr._id)
           l._commit()
-          l.set_tags(tags)
           l.update_url_cache(old_url)
           if edit:
             edit._commit()

--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -503,8 +503,8 @@ class FrontController(RedditController):
               can_submit = VSRSubmitPage(),
               url = VRequired('url', None),
               title = VRequired('title', None),
-              tags = VTags('tags'))
-    def GET_submit(self, can_submit, url, title, tags):
+    )
+    def GET_submit(self, can_submit, url, title):
         """Submit form."""
         if not can_submit:
             return BoringPage(_("Not Enough Karma"),
@@ -552,7 +552,6 @@ class FrontController(RedditController):
                         show_sidebar = True,
                         content=NewLink(title=title or '',
                                         subreddits = srs,
-                                        tags=tags,
                                         sr_id = sr._id if sr else None,
                                         captcha=captcha)).render()
 
@@ -574,7 +573,7 @@ class FrontController(RedditController):
 
         return FormPage(_("Edit article"),
                       show_sidebar = True,
-                      content=EditLink(article, subreddits=subreddits, tags=article.tag_names(), captcha=captcha)).render()
+                      content=EditLink(article, subreddits=subreddits, captcha=captcha)).render()
 
     def _render_opt_in_out(self, msg_hash, leave):
         """Generates the form for an optin/optout page"""

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -989,7 +989,7 @@ class EmailVerify(Wrapped):
     pass
 
 class ReportEmail(Wrapped):
-    """Email template. Informs the contact email address that a user 
+    """Email template. Informs the contact email address that a user
     has reported a post"""
     pass
 
@@ -1162,9 +1162,9 @@ class FrameToolbar(Wrapped):
 
 class NewLink(Wrapped):
     """Render the link submission form"""
-    def __init__(self, captcha = None, article = '', title= '', subreddits = (), tags = (), sr_id = None):
+    def __init__(self, captcha = None, article = '', title= '', subreddits = (), sr_id = None):
         Wrapped.__init__(self, captcha = captcha, article = article,
-                         title = title, subreddits = subreddits, tags = tags,
+                         title = title, subreddits = subreddits,
                          sr_id = sr_id, notify_on_comment = True,
                          cc_licensed = True)
 

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -152,7 +152,7 @@ class Link(Thing, Printable, ImageHolder):
         return submit_url
 
     @classmethod
-    def _submit(cls, title, article, author, sr, ip, tags, spam = False, date = None, **kwargs):
+    def _submit(cls, title, article, author, sr, ip, spam = False, date = None, **kwargs):
         # Create the Post and commit to db.
         l = cls(title = title,
                 url = 'self',
@@ -176,10 +176,6 @@ class Link(Thing, Printable, ImageHolder):
         l.set_article(article)
 
         l.set_url_cache()
-
-        # Add tags
-        for tag in tags:
-            l.add_tag(tag)
 
         return l
 
@@ -1247,14 +1243,6 @@ class Comment(Thing, Printable):
 
         if should_invalidate:
             g.rendercache.delete('side-comments' + '-' + c.site.name)
-            tags = Link._byID(self.link_id, data = True).tag_names()
-            if 'open_thread' in tags:
-                g.rendercache.delete('side-open' + '-' + c.site.name)
-            if 'quotes' in tags:
-                g.rendercache.delete('side-quote' + '-' + c.site.name)
-            if 'group_rationality_diary' in tags:
-                g.rendercache.delete('side-diary' + '-' + c.site.name)
-
 
 class InlineComment(Comment):
     """Exists to gain a different render_class in Wrapped"""

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -63,14 +63,6 @@
     <tr>
       <td><textarea id="article" name="article" rows="35">${thing.article}</textarea></td>
     </tr>
-    <tr>
-      <td>
-        <label for="tags">${_("Tags:")}</label>
-        <input id="tags" name="tags" value="${', '.join(thing.tags)}"
-                   onfocus="clearTitle(this)" type="text" />
-        <span class="gray">${_('Enter tags separated by commas or spaces.')}</span>
-      </td>
-    </tr>
     %if thing.subreddits:
       <tr>
         <td>
@@ -128,17 +120,14 @@
 
       if(form) {
         setMessage(form.title, ${json(_('Enter a title for the article.'))});
-        setMessage(form.tags, ${json(_('Enter tags separated by commas or spaces.'))});
 
         form.title.setAttribute("data-orig-value", form.title.value);
         form.article.setAttribute("data-orig-value", form.article.value);
-        form.tags.setAttribute("data-orig-value", form.tags.value);
 
         function unsavedPrompt() {
           var message = "You've made changes to the article, but haven't submitted it.";
 
-          if ((form.title.value && form.title.value !== form.title.getAttribute("data-orig-value")) ||
-              (form.tags.value && form.tags.value !== form.tags.getAttribute("data-orig-value")))
+          if (form.title.value && form.title.value !== form.title.getAttribute("data-orig-value"))
             return message;
 
           // Ensure that TinyMCE has saved the content back to the textarea


### PR DESCRIPTION
I don't think we display tags anywhere on the site, so there's no point in letting people tag their articles.

Before:
![tags-yes](https://cloud.githubusercontent.com/assets/1735266/18192930/72b43f86-708d-11e6-8b76-6a122a0c771f.png)

After:
![tags-no](https://cloud.githubusercontent.com/assets/1735266/18192929/72b06cee-708d-11e6-89af-a3d010fa3bb1.png)
