### PR TITLE
Redirect to article page after upvote-triggered log-in.

### DIFF
--- a/r2/development.ini
+++ b/r2/development.ini
@@ -153,6 +153,7 @@ karma_to_vote_on_polls = 0
 karma_to_vote_in_overview = 1000
 karma_percentage_to_be_voted = 80
 downvoted_reply_score_threshold = -4
+hide_comment_threshold = -4
 downvoted_reply_karma_cost = 5
 
 # user preference default values

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1159,8 +1159,8 @@ class Comment(Thing, Printable):
         return permalink.unparse()
 
     def make_permalink_slow(self):
-        l = Link._byID(self.link_id, data=True)
-        return self.make_permalink(l, l.subreddit_slow)
+        link = Link._byID(self.link_id, data=True)
+        return self.make_permalink(link, link.subreddit_slow)
 
     def make_permalink_title(self, link):
         author = Account._byID(self.author_id, data=True).name

--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -1098,6 +1098,19 @@ div.comment-links {
   padding: 0 0 2px;
   margin-top: -10px;
 }
+.comment-fading-highlight {
+  animation: 2s fadingHighlight;
+  -webkit-animation: 2s fadingHighlight;
+}
+@keyframes fadingHighlight {
+  from {
+    background-color: #fcffa8;
+  }
+
+  to {
+    background-color: #ecf5ff;
+  }
+}
 div.comment-links ul, div.message-links ul {
   list-style: none;
   margin: 0;

--- a/r2/r2/templates/commentlisting.html
+++ b/r2/r2/templates/commentlisting.html
@@ -12,3 +12,9 @@
   </div>
   ${thing.content.render()}
 </div>
+
+<script>
+  var commentId = window.location.hash;
+  var $comment = jQuery(commentId);
+  $comment.addClass("comment-fading-highlight");
+</script>


### PR DESCRIPTION
This uses a fragment identifier to attempt to scroll to the correct comment. This won't work if there's not enough room below the comment to show it at the top of the screen.

I'm not sure this is an improvement.

Fixes tog22/eaforum#49.