### PR TITLE
Fix comment loading in dev environment.

### DIFF
--- a/r2/development.ini
+++ b/r2/development.ini
@@ -153,6 +153,7 @@ karma_to_vote_on_polls = 0
 karma_to_vote_in_overview = 1000
 karma_percentage_to_be_voted = 80
 downvoted_reply_score_threshold = -4
+hide_comment_threshold = -4
 downvoted_reply_karma_cost = 5
 
 # user preference default values


### PR DESCRIPTION
Before, I would get this error whenever I tried to load an article that had comments:

    Module r2.controllers.validator.validator:78 in newfn
    >>  return fn(self, *a, **kw)
    Module r2.controllers.front:197 in GET_comments
    >>  displayPane.append(listing.listing())
    Module r2.models.listing:126 in listing
    >>  wrapped_items = self.get_items(num = self.num, nested = True)
    Module r2.models.listing:57 in get_items
    >>  builder_items = self.builder.get_items(*a, **kw)
    Module r2.models.builder:625 in get_items
    >>  if cm.collapse_in_link_threads:
    Module r2.lib.wrapped:63 in __getattr__
    >>  raise AttributeError, attr
    <type 'exceptions.AttributeError'>: collapse_in_link_threads