### PR TITLE
Simplify UI for saving and publishing.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -299,8 +299,9 @@ class ApiController(RedditController):
               continue_editing = VBoolean('keep_editing'),
               notify_on_comment = VBoolean('notify_on_comment'),
               cc_licensed = VBoolean('cc_licensed'),
+              save_action = nop('link_submit_action'),
     )
-    def POST_submit(self, res, l, new_content, title, save, continue_editing, sr, ip, notify_on_comment, cc_licensed):
+    def POST_submit(self, res, l, new_content, title, save, continue_editing, sr, ip, notify_on_comment, cc_licensed, save_action):
         res._update('status', innerHTML = '')
         should_ratelimit = sr.should_ratelimit(c.user, 'link') if sr else True
 
@@ -374,20 +375,10 @@ class ApiController(RedditController):
         # flag search indexer that something has changed
         tc.changed(l)
 
-        if continue_editing:
-          path = "/edit/%s" % l._id36
-        else:
-          # make_permalink is designed for links that can be set to _top
-          # here, we need to generate an ajax redirect as if we were not on a
-          # cname.
-          cname = c.cname
-          c.cname = False
-          #path = l.make_permalink_slow()
-          path = l.make_permalink(sr, sr_path = not sr.name == g.default_sr)
-          c.cname = cname
+        path = "/edit/%s" % l._id36
+        path = set_query_parameter(path, "message", save_action)
 
         res._redirect(path)
-
 
     def _login(self, res, user, dest='', rem = None):
         self.login(user, rem = rem)

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -28,9 +28,7 @@ from pylons.controllers.util import etag_cache
 
 import hashlib
 import httplib
-import urllib
 import urllib2
-import urlparse
 from validator import *
 
 from r2.models import *
@@ -43,6 +41,7 @@ from r2.controllers import ListingController
 from r2.lib.utils import get_title, sanitize_url, timeuntil, \
     set_last_modified, remote_addr
 from r2.lib.utils import query_string, to36, timefromnow
+from r2.lib.utils.http_utils import set_query_parameter
 from r2.lib.wrapped import Wrapped
 from r2.lib.rancode import random_key
 from r2.lib.pages import FriendList, ContributorList, ModList, EditorList, \
@@ -408,17 +407,6 @@ class ApiController(RedditController):
         # TODO: This is a hack, and it doesn't work if the user clicks
         # on an anchor element after logging in because the query
         # param will disappear.
-        # TODO: This function should be in a different file.
-        # From http://stackoverflow.com/a/12897375:
-        def set_query_parameter(url, param_name, param_value):
-            scheme, netloc, path, query_string, fragment = urlparse.urlsplit(url)
-            query_params = urlparse.parse_qs(query_string)
-
-            query_params[param_name] = [param_value]
-            new_query_string = urllib.urlencode(query_params, doseq=True)
-
-            return urlparse.urlunsplit((scheme, netloc, path, new_query_string, fragment))
-
         dest_with_param = set_query_parameter(dest, "refresh", "true")
         res._redirect(dest_with_param)
 

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -1162,10 +1162,14 @@ class FrameToolbar(Wrapped):
 
 class NewLink(Wrapped):
     """Render the link submission form"""
-    def __init__(self, captcha = None, article = '', title= '', subreddits = (), sr_id = None):
+    def __init__(self, captcha = None, article = '', title= '', main_subreddit = None, draft_subreddit = None):
         Wrapped.__init__(self, captcha = captcha, article = article,
-                         title = title, subreddits = subreddits,
-                         sr_id = sr_id, notify_on_comment = True,
+                         title = title,
+                         main_subreddit = main_subreddit,
+                         draft_subreddit = draft_subreddit,
+                         notify_on_comment = True,
+                         is_published = False,
+                         permalink="",
                          cc_licensed = True)
 
 class EditLink(Wrapped):

--- a/r2/r2/lib/utils/http_utils.py
+++ b/r2/r2/lib/utils/http_utils.py
@@ -1,4 +1,6 @@
 import pytz
+import urllib
+import urlparse
 from datetime import datetime
 
 DATE_RFC822 = '%a, %d %b %Y %H:%M:%S %Z'
@@ -22,3 +24,13 @@ def read_http_date(date_str):
 def http_date_str(date):
     date = date.astimezone(pytz.timezone('GMT'))
     return date.strftime(DATE_RFC822)
+
+# From http://stackoverflow.com/a/12897375:
+def set_query_parameter(url, param_name, param_value):
+    scheme, netloc, path, query_string, fragment = urlparse.urlsplit(url)
+    query_params = urlparse.parse_qs(query_string)
+
+    query_params[param_name] = [param_value]
+    new_query_string = urllib.urlencode(query_params, doseq=True)
+
+    return urlparse.urlunsplit((scheme, netloc, path, new_query_string, fragment))

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -180,24 +180,30 @@ class Subreddit(Thing, Printable, ImageHolder):
             return False
 
     def can_submit(self, user):
+        return self.submission_permission_data(user)[0]
+
+    def can_submit_error(self, user):
+        return self.submission_permission_data(user)[1]
+
+    def submission_permission_data(self, user):
         if c.user_is_admin:
-            return True
+            return (True, "")
         elif (self.type == 'private' or self.type == 'restricted') and self.is_contributor(user):
             #restricted/private require contributorship
-            return True
+            return (True, "")
         elif not c.user.email_validated:
-            return False
+            return (False, "You need to confirm your email address.")
         elif self.is_banned(user):
-            return False
+            return (False, "You're not allowed to post.")
         elif self.is_moderator(user) or self.is_editor(user):
             # moderators and editors can always submit
-            return True
+            return (True, "")
         elif self.type == 'public':
-            return True
+            return (True, "")
         elif self == Subreddit._by_name(g.default_sr) and user.safe_karma >= g.karma_to_post:
-            return True
+            return (True, "")
         else:
-            return False
+            return (False, "You need at least {} karma to post.".format(g.karma_to_post) )
 
     def can_ban(self,user):
         return (user

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -399,6 +399,14 @@ class Subreddit(Thing, Printable, ImageHolder):
         srs.sort(key=lambda a:a.title)
         return srs
 
+    @classmethod
+    def main_subreddit(cls):
+        return cls._by_name("main")
+
+    @classmethod
+    def draft_subreddit(cls, account):
+        return cls._by_name(account.draft_sr_name)
+
     @property
     def path(self):
         return "/r/%s/" % self.name

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -591,3 +591,12 @@ div.meta.meetup strong {
 .tom-ash-social {
 	float: left;
 }
+
+.displayNone {
+  display: none;
+}
+
+button.btn-disabled {
+  cursor: not-allowed;
+  background-color: #8a8a8b !important;
+}

--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -2247,6 +2247,10 @@ div.comment-links ul li.delete a {
   font-weight: normal !important;
 }
 
+button.btn-danger {
+  background-color: #d9534f !important;
+}
+
 body.post .comment .commentreply div {
   margin-right: 20px;
 }

--- a/r2/r2/public/static/utils.js
+++ b/r2/r2/public/static/utils.js
@@ -442,7 +442,7 @@ function handleResponse(action, options) {
 
         if (cleanup_func)
             cleanup_func(res_obj);
-  
+
         var r = res_obj.response;
         if(!r)
             return;
@@ -760,4 +760,20 @@ function invalidateWikiSubmit(form) {
         }
     });
     return false;
+}
+
+// From http://stackoverflow.com/a/2091331/979838
+function getQueryVariable(variable) {
+  var query = window.location.search.substring(1);
+  var vars = query.split('&');
+  for (var i = 0; i < vars.length; i++) {
+    var pair = vars[i].split('=');
+    if (decodeURIComponent(pair[0]) == variable) {
+      return decodeURIComponent(pair[1]);
+    }
+  }
+}
+
+function getPathFromUrl(url) {
+  return url.split("?")[0];
 }

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -37,7 +37,7 @@
   ${self.form_extra()}
   <h1>${_("Submit article")}</h1>
   <div style="margin-bottom: 10px; max-width: 580px;">
-    We recently upgraded the text editor on this page. If
+    We recently overhauled this page to make it easier to use. If
     you notice something not working properly, please create an issue on
     <a href="https://github.com/tog22/eaforum/issues">GitHub</a> or
     <a href="mailto:pbrinichlanglois@gmail.com?subject=EA Forum bug report">e-mail</a>

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -34,22 +34,18 @@
 <%def name="form_extra()"></%def>
 
 <%call expr="submit_form(action='/submit', _class='long-text content', _id='newlink')">
-  %if not thing.subreddits:
-    <input type="hidden" name="sr" value="${c.site.name}" />
-  %endif
   ${self.form_extra()}
-  %if thing.subreddits:
-    <h1>${_("Submit article")}</h1>
-    <div style="margin-bottom: 10px; max-width: 580px;">
-      We recently upgraded the text editor on this page. If
-      you notice something not working properly, please create an issue on
-      <a href="https://github.com/tog22/eaforum/issues">GitHub</a> or
-      <a href="mailto:pbrinichlanglois@gmail.com?subject=EA Forum bug report">e-mail</a>
-      us, and we'll do our best to fix it.
-    </div>
-  %else:
-    <h1>${_("Submit article to %(site)s") % dict(site=c.site.name)}</h1>
-  %endif
+  <h1>${_("Submit article")}</h1>
+  <div style="margin-bottom: 10px; max-width: 580px;">
+    We recently upgraded the text editor on this page. If
+    you notice something not working properly, please create an issue on
+    <a href="https://github.com/tog22/eaforum/issues">GitHub</a> or
+    <a href="mailto:pbrinichlanglois@gmail.com?subject=EA Forum bug report">e-mail</a>
+    us, and we'll do our best to fix it.
+  </div>
+
+  <div class="js-link-confirmation-message infobar displayNone"></div>
+
   <table>
     <tr>
       <td>
@@ -63,25 +59,6 @@
     <tr>
       <td><textarea id="article" name="article" rows="35">${thing.article}</textarea></td>
     </tr>
-    %if thing.subreddits:
-      <tr>
-        <td>
-          <label for="sr">${_("Post to")}</label>
-          <select id="sr" name="sr">
-            %for sr in thing.subreddits:
-              <option value="${sr.name}"
-                      %if not sr.can_submit(c.user):
-                        disabled="disabled"
-                      %elif sr._id == thing.sr_id:
-                        selected="selected"
-                      %endif
-              >${sr.title} ${_('(Your karma must be at least %d to post here)' % g.karma_to_post) if not sr.can_submit(c.user) else ''}
-              </option>
-            %endfor
-          </select>
-        </td>
-      </tr>
-    %endif
     <tr>
       <td>
         ${checkbox("notify_on_comment", _("Notify me of new top level comments on this article"), thing.notify_on_comment)}
@@ -102,10 +79,31 @@
     %endif
     <tr>
       <td>
-        <input type="hidden" id="keep_editing" name="keep_editing" value="off" />
-        <button class="btn" type="submit">${_("Submit")}</button>
-        <button class="btn" type="submit"
-          onclick="continueEditing(true)">${_("Save and continue")}</button>
+        %if thing.is_published:
+          <button class="js-publish-button btn" data-save-action="update" type="submit">
+            Update
+          </button>
+          <button class="js-save-button btn btn-danger"  data-save-action="unpublish" type="submit">
+            Unpublish
+          </button>
+          <a href="${thing.permalink}" target="_blank">View on Forum</a>
+        %else:
+          <button class="js-save-button btn" data-save-action="save" type="submit">
+            Save as Draft
+          </button>
+          <% allowed_to_publish = thing.main_subreddit.can_submit(c.user) %>
+          <button
+            class="js-publish-button btn ${'' if allowed_to_publish else 'btn-disabled'}"
+            ${"" if allowed_to_publish else "disabled"}
+            data-save-action="publish"
+            type="submit"
+          >
+            Publish
+          </button>
+        %endif
+        <input type="hidden" id="keep_editing" name="keep_editing" value="on" />
+        <input class="js-subreddit" name="sr" value="${thing.draft_subreddit.name}" hidden />
+        <input class="js-link-submit-action" type="hidden" name="link_submit_action" value="" />
         <span id="status" class="error"></span>
         ${error_field("RATELIMIT", "span")}
         ${error_field("SUBREDDIT_FORBIDDEN", "span")}
@@ -114,6 +112,24 @@
   </table>
 
   <script type="text/javascript">
+    (function() {
+      function updateSubredditOnClick(button, subreddit) {
+        button.click(function(event) {
+          event.preventDefault();
+          $subreddit.attr("value", subreddit);
+          var submitAction = jQuery(event.target).attr("data-save-action");
+          jQuery(".js-link-submit-action").attr("value", submitAction);
+          jQuery("#newlink").trigger("submit");
+        });
+      }
+
+      var $saveButton = jQuery(".js-save-button");
+      var $publishButton = jQuery(".js-publish-button");
+      var $subreddit = jQuery(".js-subreddit");
+
+      updateSubredditOnClick($saveButton, "${thing.draft_subreddit.name}");
+      updateSubredditOnClick($publishButton, "${thing.main_subreddit.name}");
+    })();
     (function () {
       init_tinymce("http://${get_domain(subreddit=False)}/");
       var form = $('newlink');
@@ -166,6 +182,36 @@
       $("#content").css("float", "none");
       $("#content").css("padding", "30px 32px 0 32px");
       $("#content").css("width", "auto");
+
+      var messages = {
+        displayIfNecessary: function() {
+          if (this.getMessage()) {
+            this.displayMessage();
+            this.removeQueryString();
+          }
+        },
+        displayMessage: function() {
+          $(".js-link-confirmation-message")
+            .html(this.getMessage())
+            .removeClass("displayNone");
+        },
+        removeQueryString: function() {
+          history.pushState("", document.title, window.location.pathname);
+        },
+        getMessage: function() {
+          var url = "${unsafe(thing.permalink)}";
+          var messageType = getQueryVariable("message");
+          var messages = {
+            "update": "Your published article has been updated. <a href='${unsafe(thing.permalink)}'>View</a>",
+            "unpublish": "Your article is no longer publicly visible.",
+            "save": "Your draft was saved.",
+            "publish": "Your article is published. <a href='${unsafe(thing.permalink)}'>View</a>",
+          };
+          return messages[messageType];
+        },
+      };
+
+      messages.displayIfNecessary();
     });
 
   })(jQuery);

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -212,7 +212,7 @@
             "update": "Your published article has been updated. <a href='${unsafe(thing.permalink)}'>View</a>",
             "unpublish": "Your article is no longer publicly visible.",
             "save": "Your draft was saved.",
-            "publish": "Your article is published. <a href='${unsafe(thing.permalink)}'>View</a>",
+            "publish": "Your article is published. <a href='${unsafe(thing.permalink)}' target='_blank'>View</a>",
           };
           return messages[messageType];
         },

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -45,6 +45,13 @@
   </div>
 
   <div class="js-link-confirmation-message infobar displayNone"></div>
+  <% allowed_to_publish = thing.main_subreddit.can_submit(c.user) %>
+  <% not_allowed_to_publish_error_message = thing.main_subreddit.can_submit_error(c.user) %>
+  %if not allowed_to_publish:
+    <div class="infobar">
+      ${not_allowed_to_publish_error_message}
+    </div>
+  %endif
 
   <table>
     <tr>
@@ -91,12 +98,12 @@
           <button class="js-save-button btn" data-save-action="save" type="submit">
             Save as Draft
           </button>
-          <% allowed_to_publish = thing.main_subreddit.can_submit(c.user) %>
           <button
             class="js-publish-button btn ${'' if allowed_to_publish else 'btn-disabled'}"
             ${"" if allowed_to_publish else "disabled"}
             data-save-action="publish"
             type="submit"
+            title="${not_allowed_to_publish_error_message}"
           >
             Publish
           </button>


### PR DESCRIPTION
See tog22/eaforum#62 for the motivation.

This would make adding more sub-forums much more difficult. (Less Wrong has Discussion and Main.) I'm not sure whether the trade-off is worthwhile. 

The volume on the EA forum is pretty low, and more-casual discussions happen on Facebook. If a need arose for sorting content, these changes (including removing tags) would make doing so more difficult.

But that that problem is hypothetical, and that the EA Forum will probably need to be replaced within a couple of years. So I'm OK with making decisions on that time horizon.

New-article UI:

![draft-before-save](https://cloud.githubusercontent.com/assets/1735266/18940923/3815f7d6-85c1-11e6-821a-6728765009a0.png)

After clicking "Save as Draft":

![draft-save-confirmation](https://cloud.githubusercontent.com/assets/1735266/18940922/3815edea-85c1-11e6-9654-0de990076a57.png)

After clicking "Publish":

![published-confirmation](https://cloud.githubusercontent.com/assets/1735266/18940924/3816ca4e-85c1-11e6-9fdf-c70dc90408bc.png)

![unpublish-ui](https://cloud.githubusercontent.com/assets/1735266/18940919/37d18db2-85c1-11e6-85e3-90a9fa0b1fbe.png)

After clicking "Update":

![updated-confirmation](https://cloud.githubusercontent.com/assets/1735266/18940920/37fe45dc-85c1-11e6-8231-f990337baaea.png)

After clicking "Unpublish":

![unpublish-confirmation](https://cloud.githubusercontent.com/assets/1735266/18940921/380cdf2a-85c1-11e6-8bbf-f3a875b1b936.png)

#49 should be merged first.