### PR TITLE
Allow drafts to be previewed

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -568,15 +568,14 @@ class FrontController(RedditController):
         captcha = Captcha(tabular=False) if c.user.needs_captcha() else None
         draft_subreddit = Subreddit.draft_subreddit(author)
         main_subreddit = Subreddit.main_subreddit()
-        is_published = article.sr_id == main_subreddit._id
+        published_status = "published" if article.sr_id == main_subreddit._id else "draft"
 
         edit_link = EditLink(article,
-                             subreddits=subreddits,
-                             draft_subreddit=draft_subreddit,
-                             main_subreddit=main_subreddit,
-                             permalink=article.make_permalink_slow(),
-                             is_published=is_published,
-                             captcha=captcha)
+                             draft_subreddit = draft_subreddit,
+                             main_subreddit = main_subreddit,
+                             permalink = article.make_permalink_slow(),
+                             published_status = published_status,
+                             captcha = captcha)
 
         return FormPage(_("Edit article"), show_sidebar = True, content=edit_link).render()
 

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -1168,7 +1168,7 @@ class NewLink(Wrapped):
                          main_subreddit = main_subreddit,
                          draft_subreddit = draft_subreddit,
                          notify_on_comment = True,
-                         is_published = False,
+                         published_status = "new",
                          permalink="",
                          cc_licensed = True)
 

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -86,14 +86,14 @@
     %endif
     <tr>
       <td>
-        %if thing.is_published:
+        %if thing.published_status == "published":
           <button class="js-publish-button btn" data-save-action="update" type="submit">
             Update
           </button>
           <button class="js-save-button btn btn-danger"  data-save-action="unpublish" type="submit">
             Unpublish
           </button>
-          <a href="${thing.permalink}" target="_blank">View on Forum</a>
+          <a href="${thing.permalink}" target="_blank">View</a>
         %else:
           <button class="js-save-button btn" data-save-action="save" type="submit">
             Save as Draft
@@ -107,6 +107,9 @@
           >
             Publish
           </button>
+          %if thing.published_status == "draft":
+            <a href="${thing.permalink}" target="_blank">Preview</a>
+          %endif
         %endif
         <input type="hidden" id="keep_editing" name="keep_editing" value="on" />
         <input class="js-subreddit" name="sr" value="${thing.draft_subreddit.name}" hidden />
@@ -209,9 +212,9 @@
           var url = "${unsafe(thing.permalink)}";
           var messageType = getQueryVariable("message");
           var messages = {
-            "update": "Your published article has been updated. <a href='${unsafe(thing.permalink)}'>View</a>",
+            "update": "Your published article has been updated. <a href='${unsafe(thing.permalink)}' target="_blank">View</a>",
             "unpublish": "Your article is no longer publicly visible.",
-            "save": "Your draft was saved.",
+            "save": "Your draft was saved. <a href='${unsafe(thing.permalink)}' target='_blank'>Preview</a>",
             "publish": "Your article is published. <a href='${unsafe(thing.permalink)}' target='_blank'>View</a>",
           };
           return messages[messageType];


### PR DESCRIPTION
Fixes tog22/eaforum#76

Not the best design, since the "View/Preview" link in the confirmation message is sometimes redundant with the link next to the "Publish/Unpublish" button.

![preview](https://cloud.githubusercontent.com/assets/1735266/19839347/313b24b4-9e9d-11e6-8f32-5b48221adefe.png)

![view](https://cloud.githubusercontent.com/assets/1735266/19839348/34164dbc-9e9d-11e6-85d5-566b003e245d.png)
