### PR TITLE
mobile-style: followup

### DIFF
--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -665,6 +665,9 @@ button.btn-disabled {
     #sidebar #feeds ul li a {
       font-size: 24px;
     }
+    #side-comments {
+      font-size: 24px;
+    }
     #content .post h1 a {
       font-size: 32px;
     }
@@ -703,6 +706,9 @@ button.btn-disabled {
       font-size: 18px;
     }
     .comment-links {
+      zoom: 2;
+    }
+    .tools {
       zoom: 2;
     }
   }

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -689,6 +689,12 @@ button.btn-disabled {
       font-size: 24px;
       line-height: 26px;
     }
+    div.post h3 {
+      font-size: 32px;
+    }
+    div.post h2 {
+      font-size: 34px;
+    }
     #content .post .post-body .post-comment-count a {
       font-size: 24px;
     }

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -617,19 +617,9 @@ button.btn-disabled {
     width: auto;
     float: none;
     margin-left: 34px;
-    font-size: 28px;
   }
   .linkbox {
     margin-top: 28px;
-  }
-  #sidebar h2 {
-    font-size: 32px;
-  }
-  #sidebar .linkbox li a {
-    font-size: 24px;
-  }
-  #sidebar #feeds ul li a {
-    font-size: 24px;
   }
   #side-search { display: none; }
   #wrapper {
@@ -641,16 +631,8 @@ button.btn-disabled {
   div.post h1 {
     padding-left: 34px;
   }
-  #content .post h1 a {
-    font-size: 32px;
-  }
   #content .post .post-body h2 {
     padding-left: 34px;
-    font-size: 32px;
-    line-height: normal;
-  }
-  #content .post .post-body .content .md {
-    font-size: 32px;
   }
   #content .post .post-body {
     margin-left: 5px;
@@ -660,38 +642,68 @@ button.btn-disabled {
     width: 690px;
     word-wrap: break-word;
   }
-  .md { font-size: 32px; }
-  ul#nav li {
-    font-size: 20px;
-  }
-  div.post div.postedby {
-    font-size: 24px;
-    line-height: 26px;
-  }
-  #content .post .post-body .post-comment-count a {
-    font-size: 24px;
-  }
-  div.footer {
-    font-size: 18px;
-    height: 32px;
-  }
-  div.comment-meta span {
-    font-size: 32px;
-  }
-  #wrapper {
-    font-size: 20px;
-  }
   #comments {
     margin-left: 5px;
   }
-  #comments h2 {
-    font-size: 28px;
-  }
-  #comment-controls div.filter-inactive, #comment-controls div.filter-active {
-    font-size: 18px;
-  }
-  .comment-links {
-    zoom: 2;
-  }
   html * {max-height:1000000px;}
+
+  /* to keep from making things look giant on tablets and narrow
+  desktop screens, only make fonts bigger if the device-width is low.
+  Phones will have a device-width of under 450px, while tablets will
+  have a device width of over 600px, so this pulls them apart pretty
+  well */
+  @media only screen and (max-device-width: 550px) {
+    #sidebar {
+      font-size: 28px;
+    }
+    #sidebar h2 {
+      font-size: 32px;
+    }
+    #sidebar .linkbox li a {
+      font-size: 24px;
+    }
+    #sidebar #feeds ul li a {
+      font-size: 24px;
+    }
+    #content .post h1 a {
+      font-size: 32px;
+    }
+    #content .post .post-body h2 {
+      font-size: 32px;
+      line-height: normal;
+    }
+    #content .post .post-body .content .md {
+      font-size: 32px;
+    }
+    .md { font-size: 32px; }
+    ul#nav li {
+      font-size: 20px;
+    }
+    div.post div.postedby {
+      font-size: 24px;
+      line-height: 26px;
+    }
+    #content .post .post-body .post-comment-count a {
+      font-size: 24px;
+    }
+    div.footer {
+      font-size: 18px;
+      height: 32px;
+    }
+    div.comment-meta span {
+      font-size: 32px;
+    }
+    #wrapper {
+      font-size: 20px;
+    }
+    #comments h2 {
+      font-size: 28px;
+    }
+    #comment-controls div.filter-inactive, #comment-controls div.filter-active {
+      font-size: 18px;
+    }
+    .comment-links {
+      zoom: 2;
+    }
+  }
 }

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -714,6 +714,10 @@ button.btn-disabled {
     #comment-controls div.filter-inactive, #comment-controls div.filter-active {
       font-size: 18px;
     }
+    body.post .commentreply textarea,
+    body.meetup .commentreply textarea {
+      font-size: 36px;
+    }
     .comment-links {
       zoom: 2;
     }

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -668,6 +668,9 @@ button.btn-disabled {
     #side-comments {
       font-size: 24px;
     }
+    #sidebar div.contributors li.user a {
+      font-size: 24px;
+    }
     #content .post h1 a {
       font-size: 32px;
     }

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -612,7 +612,25 @@ button.btn-disabled {
 /* Mobile version.  This overrides styles for small screens, and so needs to stay at the
    end of the CSS. */
 @media only screen and (max-width: 750px)  {
-  #sidebar { display: none; }
+  #banner { zoom: 0.75 }
+  #sidebar {
+    width: auto;
+    float: none;
+    margin-left: 34px;
+    font-size: 28px;
+  }
+  .linkbox {
+    margin-top: 28px;
+  }
+  #sidebar h2 {
+    font-size: 32px;
+  }
+  #sidebar .linkbox li a {
+    font-size: 24px;
+  }
+  #sidebar #feeds ul li a {
+    font-size: 24px;
+  }
   #side-search { display: none; }
   #wrapper {
     width: 750px;
@@ -628,6 +646,8 @@ button.btn-disabled {
   }
   #content .post .post-body h2 {
     padding-left: 34px;
+    font-size: 32px;
+    line-height: normal;
   }
   #content .post .post-body .content .md {
     font-size: 32px;
@@ -653,6 +673,7 @@ button.btn-disabled {
   }
   div.footer {
     font-size: 18px;
+    height: 32px;
   }
   div.comment-meta span {
     font-size: 32px;


### PR DESCRIPTION
* fix post titles on the landing page being too small
* put the sidebar at the bottom instead of hiding it entirely
* shrink the banner instead of truncating the right side
* make the footer tall enough to hold the larger font size it has now
* keep the make-things-bigger changes from applying to tablets

See it live:

Screenshots from a phone:

http://www.jefftk.com/ea-testing/landing-top-old.png
http://www.jefftk.com/ea-testing/landing-top-new.png

http://www.jefftk.com/ea-testing/landing-bottom-old.png
http://www.jefftk.com/ea-testing/landing-bottom-new.png

http://www.jefftk.com/ea-testing/comments-bottom-old.png
http://www.jefftk.com/ea-testing/comments-bottom-new.png

Screenshots from chrome's ipad emulation:

http://www.jefftk.com/ea-testing/landing-ipad-old.png
http://www.jefftk.com/ea-testing/landing-ipad-new.png