### PR TITLE
Revert "Merge pull request #64 from patbl/recaptcha"

### DIFF
--- a/r2/development.ini
+++ b/r2/development.ini
@@ -98,8 +98,6 @@ meetup_grace_period = 3600
 solr_url =
 
 google_api_key = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbbbbbbbbbbbbbbbbbbb_cccccccccccccccccc-d
-recaptcha_secret_key = "6LdPdwwUAAAAADnKEZeA2BJF_Md6e_k4-w1bcoHx"
-recaptcha_site_key = "6LdPdwwUAAAAANKmGJf5fKsWsVanZi6y6hBJ-9mW"
 SECRET    = abcdefghijklmnopqrstuvwxyz0123456789
 MODSECRET = abcdefghijklmnopqrstuvwxyz0123456789
 tracking_secret = abcdefghijklmnopqrstuvwxyz0123456789

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -28,9 +28,7 @@ from pylons.controllers.util import etag_cache
 
 import hashlib
 import httplib
-import urllib
 import urllib2
-import json
 from validator import *
 
 from r2.models import *
@@ -422,7 +420,7 @@ class ApiController(RedditController):
 
 
     @Json
-    @validate(VRecaptcha('g-recaptcha-response'),
+    @validate(VCaptcha(),
               VRatelimit(rate_ip = True, prefix='rate_register_'),
               name = VUname(['user_reg']),
               email = ValidEmail('email_reg'),
@@ -454,7 +452,7 @@ class ApiController(RedditController):
             res._focus('passwd2_reg')
         elif res._chk_error(errors.DRACONIAN, op):
             res._focus('legal_reg')
-        elif res._chk_captcha(errors.BAD_RECAPTCHA):
+        elif res._chk_captcha(errors.BAD_CAPTCHA):
             pass
         elif res._chk_error(errors.RATELIMIT, op):
             pass

--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -31,9 +31,6 @@ from r2.lib.template_helpers import add_sr
 from r2.lib.jsonresponse import json_respond
 from r2.lib.errors import errors, UserRequiredException
 from r2.lib.utils import http_utils
-import urllib
-import urllib2
-import json
 
 from r2.models import *
 
@@ -448,25 +445,6 @@ class VCaptcha(Validator):
         if (not c.user_is_loggedin or c.user.needs_captcha()):
             if not captcha.valid_solution(iden, solution):
                 c.errors.add(errors.BAD_CAPTCHA)
-
-class VRecaptcha(Validator):
-    RECAPTCHA_VALIDATION_URL = "https://www.google.com/recaptcha/api/siteverify"
-
-    def run(self, recaptcha_response):
-        if not recaptcha_response:
-            c.errors.add(errors.BAD_RECAPTCHA)
-            return
-
-        request_data = {
-            "secret": g.recaptcha_secret_key,
-            "response": recaptcha_response,
-        }
-        query_params = urllib.urlencode(request_data)
-        request = urllib2.Request(self.RECAPTCHA_VALIDATION_URL, query_params)
-        response = urllib2.urlopen(request)
-        response_data = json.load(response)
-        if not response_data["success"]:
-            c.errors.add(errors.BAD_RECAPTCHA)
 
 class VUser(Validator):
     def run(self, password = None):

--- a/r2/r2/lib/errors.py
+++ b/r2/r2/lib/errors.py
@@ -6,16 +6,16 @@
 # software over a computer network and provide for limited attribution for the
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
-#
+# 
 # Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
-#
+# 
 # The Original Code is Reddit.
-#
+# 
 # The Original Developer is the Initial Developer.  The Initial Developer of the
 # Original Code is CondeNet, Inc.
-#
+# 
 # All portions of the code written by CondeNet are Copyright (c) 2006-2008
 # CondeNet, Inc. All Rights Reserved.
 ################################################################################
@@ -31,7 +31,6 @@ error_list = dict((
         ('LOCATION_TOO_LONG', _('Location is too long')),
         ('COMMENT_TOO_LONG', _('Comment too long')),
         ('BAD_CAPTCHA', _('Incorrect, try again')),
-        ('BAD_RECAPTCHA', _('Please click "I\'m not a robot" or refresh the page and try again.')),
         ('BAD_USERNAME', _('Invalid user name')),
         ('BAD_USERNAME_SHORT', _('Username is too short')),
         ('BAD_USERNAME_LONG', _('Username is too long')),
@@ -95,7 +94,7 @@ class Error(object):
         self.name = name
         self.i18n_message = i18n_message
         self.msg_params = msg_params or {}
-
+        
     @property
     def message(self):
         return _(self.i18n_message) % self.msg_params
@@ -124,10 +123,10 @@ class ErrorSet(object):
     def __iter__(self):
         for x in self.errors:
             yield x
-
+        
     def _add(self, error_name, msg, msg_params = None):
         self.errors[error_name] = Error(error_name, msg, msg_params)
-
+        
     def add(self, error_name, msg_params = None):
         msg = error_list[error_name]
         self._add(error_name,  msg, msg_params = msg_params)

--- a/r2/r2/public/static/eaforum.css
+++ b/r2/r2/public/static/eaforum.css
@@ -58,14 +58,6 @@ div.permamessage {
     width: 250px;
  }
 
-.SignupForm-recaptcha {
-  transform: scale(0.71);
-  -webkit-transform: scale(0.71);
-  transform-origin: 0 0;
-  -webkit-transform-origin: 0 0;
-  height: 56px;
-}
-
 /* cover */
 .cover {
     position: fixed;

--- a/r2/r2/public/static/reddit_piece.js
+++ b/r2/r2/public/static/reddit_piece.js
@@ -241,12 +241,6 @@ function chklogin(form) {
             post_form(form, 'register');
             if (window.pageTracker)
                 window.pageTracker._trackPageview('/NewSignup');
-            // We reset the CAPTCHA because if the form was invalid, a
-            // fresh CAPTCHA will be needed (they are single-use). It
-            // would make more sense to validate the CAPTCHA only if the
-            // rest of the form is valid, but I couldn't figure out how
-            // to do this within the current validation system.
-            grecaptcha.reset();
         }
         return false;
     }

--- a/r2/r2/templates/base.html
+++ b/r2/r2/templates/base.html
@@ -72,7 +72,6 @@ eaforum.css. -->
 
     ${self.head()}
     <script src="//load.sumome.com/" data-sumo-site-id="2115f2f4b9e86f1f2e73c48fb896958ad06ae47bfb80face9329b72cb21fca6c" async="async"></script>
-    <script src="https://www.google.com/recaptcha/api.js"></script>
   </head>
 
   ${self.bodyHTML()}

--- a/r2/r2/templates/login.html
+++ b/r2/r2/templates/login.html
@@ -26,6 +26,7 @@
    from r2.lib.utils import UrlParser
    import random
  %>
+<%namespace file="captcha.html" import="captchagen"/>
 <%namespace file="utils.html" import="error_field, plain_link, text_with_links, img_link"/>
 
 ## default content
@@ -34,6 +35,9 @@
 %else:
   ${login_panel(user_reg = thing.user_reg, user_login = thing.user_login,
                 dest=thing.dest)}
+  <script type="text/javascript">
+    new_captcha();
+  </script>
 %endif
 
 <%def name="login_form(register=False, user='', dest='')">
@@ -92,15 +96,9 @@
           ${error_field("BAD_PASSWORD_MATCH_" + op, kind="span")}
         </li>
         <li>
+          ${captchagen('', tabulate=True, label=False, size=30)}
           ${error_field("DRACONIAN_" + op, kind="span")}
           ${error_field("RATELIMIT_" + op, kind="span")}
-        </li>
-        <li>
-          <div
-            class="g-recaptcha SignupForm-recaptcha"
-            data-sitekey="${g.recaptcha_site_key}"
-          ></div>
-          ${error_field("BAD_RECAPTCHA", kind="span")}
         </li>
       %endif
       <li>


### PR DESCRIPTION
This reverts commit f433dbc87e17ecb61ae7e38608a3651fa6ac8300, reversing
changes made to c6f785bb641e9c011a5b3c86189d994ec6ee9460.

There are two errors. This one appears on page load:

Uncaught SecurityError: Failed to read the 'contentDocument' property from 'HTMLIFrameElement': Blocked a frame with origin "http://lesswrong.local:8080" from accessing a frame with origin "https://www.google.com".  The frame requesting access has a protocol of "http", the frame being accessed has a protocol of "https". Protocols must match.

This one appears after you check "I'm not a robot":

GET https://www.google.com/recaptcha/api2/frame?c=03AHJ_VuurNoNetM7J7L9jDGFWIU8…N6OswbeKlQAmI4i1gI5KxjdCKiQcbbjFLAswwxM6hfaOCQDM5FQW0_BEY9AoDvUemLignCWiCA 400 (OK)

There seems to be an elevated rate of people complaining about getting 400s from Recaptcha in the past week:

https://blog.torproject.org/comment/reply/1265/226461
https://groups.google.com/forum/#!topic/recaptcha/h4_rYWxe0V0
https://groups.google.com/forum/#!topic/recaptcha/xrErVxHBAM0
http://stackoverflow.com/questions/41247200/recaptcha-error-400

I tried loading the script with HTTP instead of HTTPS, but that doesn't fix the initial error because the script itself inserts an iframe that has an HTTPS URL. It's not clear whether the initial error is what's causing the subsequent error.