### PR TITLE
CSS: Add some spacing after list items

### DIFF
--- a/r2/r2/public/static/main.css
+++ b/r2/r2/public/static/main.css
@@ -1772,6 +1772,10 @@ body.post #content .post .post-body .post-info {
   font-size: 16px;
 }
 
+#content .post .post-body .content .md li {
+  margin-bottom: 12px;
+}
+
 #content .post .action-bar {
   border-top: 1px solid #ddd;
   padding: 13px 0 0;


### PR DESCRIPTION
Fixes tog22/eaforum#87.
![lists](https://user-images.githubusercontent.com/1735266/27370407-4b3dd858-5611-11e7-9592-a61666f0ecdb.png)
