### PR TITLE
Fixes tog22/eaforum#86

### DIFF
--- a/r2/r2/templates/feedbox.html
+++ b/r2/r2/templates/feedbox.html
@@ -5,7 +5,6 @@
    title_id = "%s_title" % container_id
 %>
 <div class="sidebox" id="feeds">
-  <!--
   <h2>Recently on EA Blogs</h2>
   <ul id="${container_id}"></ul>
   <script type="text/javascript">
@@ -49,5 +48,4 @@
       }
     });
   </script>
-  -->
 </div>

--- a/r2/r2/templates/reddit.html
+++ b/r2/r2/templates/reddit.html
@@ -105,7 +105,7 @@
     <script src="${static('ie8below.js')}"  type="text/javascript"></script>
     <![endif]-->
 
-  <script type="text/javascript" src="http://www.google.com/jsapi"></script>
+  <script type="text/javascript" src="https://rss2json.com/gfapi.js"></script>
 </%def>
 
 <%def name="javascript_run()">


### PR DESCRIPTION
Replaces the google feed api with a replacement: https://rss2json.com/google-feed-api-alternative

Revert "Temporarily comments out the broken 'recently on EA Blogs' item."